### PR TITLE
chore: update pyvespa to fix CVE-2026-41066

### DIFF
--- a/ranking/ch2/evaluation/requirements.txt
+++ b/ranking/ch2/evaluation/requirements.txt
@@ -1,4 +1,4 @@
 requests
 openai
-pyvespa
+pyvespa>=1.1.2
 python-dotenv

--- a/ranking/ch3/train_reranker/requirements.txt
+++ b/ranking/ch3/train_reranker/requirements.txt
@@ -1,6 +1,6 @@
 requests
 openai
-pyvespa
+pyvespa>=1.1.2
 python-dotenv
 numpy
 pandas

--- a/ranking/ch4/dataset/requirements.txt
+++ b/ranking/ch4/dataset/requirements.txt
@@ -1,4 +1,4 @@
-pyvespa
+pyvespa>=1.1.2
 requests
 tqdm
 python-dotenv


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**

## Summary
Pins `pyvespa` to a minimum version of >=1.1.2 across three `requirements.txt` files in the ranking course chapters, to pick up a security fix released in pyvespa 1.1.2. Previously these files specified `pyvespa` with no version constraint.

## Changed Files
- `ranking/ch2/evaluation/requirements.txt` — `pyvespa` → `pyvespa>=1.1.2`
- `ranking/ch3/train_reranker/requirements.txt` — `pyvespa` → `pyvespa>=1.1.2`
- `ranking/ch4/dataset/requirements.txt` — `pyvespa` → `pyvespa>=1.1.2`

## CVEs Addressed
CVE addressed in pyvespa 1.1.2 (verify exact CVE ID in the pyvespa 1.1.2 release notes)

## ⚠️ Review Notes
- All three affected `requirements.txt` files were updated consistently.
- The change adds a minimum version floor rather than an exact pin, so the installed version will be the latest pyvespa >=1.1.2 at install time.
- No other dependency files (pyproject.toml, lock files) exist for these chapters.
- pyvespa 1.1.2 is confirmed to exist on PyPI.
- Note: `ranking/ch2/evaluation/requirements.txt` and `ranking/ch4/dataset/requirements.txt` are missing a trailing newline — this is a pre-existing issue, not introduced by this PR.

## Verification Steps
1. Run `pip install -r ranking/ch2/evaluation/requirements.txt` (and equivalents for ch3/ch4) and confirm pyvespa >=1.1.2 is resolved.
2. Run `pip-audit` or `safety check` to confirm the CVE is no longer flagged.
3. Smoke-test the notebooks/scripts in each chapter to confirm they still run correctly with the updated pyvespa version.