### PR TITLE
check-setup.sh: skip over "Got config" messages

### DIFF
--- a/101/check-setup.sh
+++ b/101/check-setup.sh
@@ -2,14 +2,14 @@
 
 cd $HOME
 
-tgt=$(vespa config get target -c never 2>&1)
+tgt=$(vespa config get target -c never | grep -v "^Got" 2>&1)
 if [ "$tgt" != "target = cloud" ]; then
 	msg="Configure the CLI to target Vespa Cloud: vespa config set target cloud"
 	echo "$msg"
 	exit 1
 fi
 
-app=$(vespa config get application -c never 2>&1)
+app=$(vespa config get application -c never | grep -v "^Got" 2>&1)
 if [ "$app" = "application = <unset>" ]; then
 	msg="Configure the CLI: vespa config set application <tenant>.<application>"
 	echo "$msg"


### PR DESCRIPTION
vespa-cli now outputs something like:
```
Got global config from /home/student/.vespa/config.yaml
```

When running `get target` or `get application`.

Which breaks check-setup. This patch works around this change. It's quite ugly to use `grep -v` for that, but I don't see a cleaner way.