### PR TITLE
101 ch4 queries.http: example that works

### DIFF
--- a/101/ch4/queries.http
+++ b/101/ch4/queries.http
@@ -37,9 +37,13 @@ Content-Type: application/json
 #     --timeout 60 \
 #     --header="X-LLM-API-KEY:insert-api-key-here" \
 #     query="what kind of mini stencils do you have for sale?" \
+#     query_text="mini stencil" \
+#     'input.query(embedding_query_variable)'='embed(@query_text)' \
+#     yql='select * from product where title contains @query_text OR ({targetHits:100}nearestNeighbor(EMBEDDING_FIELD,EMBEDDING_QUERY_VARIABLE))' \
+#     ranking.profile=HYBRID_SEARCH_RANK_PROFILE \
 #     presentation.summary=medium \
 #     hits=5 \
-#     searchChain=openai_search_chain \
+#     searchChain=OPENAI_SEARCH_CHAIN \
 #     format=sse \
 #     traceLevel=1
 


### PR DESCRIPTION
We had this feedback from the last round of training, that the RAG example didn't actually work (it says something like "I'm sorry, I can't find the products you're looking for").

It actually works for the HTTP request, but the CLI equivalent omitted a lot of stuff. Now they should be equivalent. Or at least the CLI one should work :)